### PR TITLE
Use IpAddr datatype consistently for IP addresses

### DIFF
--- a/lib/ddupdate/ddplugin.py
+++ b/lib/ddupdate/ddplugin.py
@@ -150,9 +150,7 @@ class IpAddr(object):
         self.v6 = ipv6
 
     def __str__(self):
-        s1 = self.v4 if self.v4 else 'None'
-        s2 = self.v6 if self.v6 else 'None'
-        return '[%s, %s]' % (s1, s2)
+        return repr([self.v4, self.v6])
 
     def __eq__(self, obj):
         if not isinstance(obj, IpAddr):


### PR DESCRIPTION
Fixes always failing comparisons of cached IPs to IPs from address
plugins. The cache was returning an address string, plugins IpAddr
objects.

 * Serialize IpAddr objects (to cache) with `IpAddr.__str__()`, using
   repr() of list [self.v4, self.v6]
 * Only serialize IpAddr objects (not strings) to cache
 * Read IpAddr objects from cache with `ast.literal_eval()`
 * Delete cache file when it cannot be read without errors. This
   applies to cache files written by previous versions of ddupdate.