### PR TITLE
Configuration `options` variable is a string

### DIFF
--- a/lib/ddupdate/config.py
+++ b/lib/ddupdate/config.py
@@ -146,8 +146,8 @@ def get_address_plugin(log, paths):
     web_default_ip = plugins['default-web-ip']
     default_if = plugins['default-if']
     print("Probing for addresses, can take some time...")
-    if_addr = default_if.get_ip(log, {})
-    web_addr = web_default_ip.get_ip(log, {})
+    if_addr = default_if.get_ip(log, '')
+    web_addr = web_default_ip.get_ip(log, '')
     print("1  Use address as seen from Internet [%s]" % web_addr.v4)
     print("2  Use address as seen on local network [%s]" % if_addr.v4)
     print("3  Use address as decided by service")

--- a/lib/ddupdate/main.py
+++ b/lib/ddupdate/main.py
@@ -271,9 +271,9 @@ def log_options(log, args):
     log.info("Using ip address plugin: " + args.address_plugin)
     log.info("Using service plugin: " + args.service_plugin)
     log.info("Service options: " +
-             (' '.join(args.service_options) if args.service_options else ''))
+             (args.service_options if args.service_options else ''))
     log.info("Address options: " +
-             (' '.join(args.address_options) if args.address_options else ''))
+             (args.address_options if args.address_options else ''))
 
 
 def load_module(path):

--- a/plugins/cloudflare.py
+++ b/plugins/cloudflare.py
@@ -160,7 +160,7 @@ class CloudflarePlugin(ServicePlugin):
             raise ServiceError("IP must be defined.")
 
         self._init_auth()
-        opts = dict_of_opts(options)
+        opts = dict_of_opts(options.split(' '))
 
         if 'zone' not in opts:
             raise ServiceError('Required option zone= missing, giving up.')

--- a/plugins/hardcoded_if.py
+++ b/plugins/hardcoded_if.py
@@ -23,7 +23,7 @@ class HardcodedIfPlugin(AddressPlugin):
 
     def get_ip(self, log, options):
         """Implement AddressPlugin.get_ip()."""
-        opts = dict_of_opts(options)
+        opts = dict_of_opts(options.split(' '))
         if 'if' not in opts:
             raise AddressError('Required option if= missing, giving up.')
         if_ = opts['if']

--- a/plugins/ip_from_cmd.py
+++ b/plugins/ip_from_cmd.py
@@ -38,7 +38,7 @@ class IpFromCmdPlugin(AddressPlugin):
 
     def get_ip(self, log, options):
         """Implement AddressPlugin.get_ip()."""
-        opts = dict_of_opts(options)
+        opts = dict_of_opts((options,))
         if 'cmd' not in opts:
             raise AddressError('Required option cmd= missing, giving up.')
         cmd = opts['cmd']


### PR DESCRIPTION
As far as I can tell, the `options` parameter that is passed to plugins is a string, and not a list of string. This patch should bring everything in-line with that interpretation.

I admit, however, that I don't understand how any plugins with configuration options could have ever worked before this, so if I strongly expect that I've misunderstood the usage of the configuration files.