### PR TITLE
systemd units are now user units

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,6 @@
 usr/bin/ddupdate
 usr/bin/ddupdate-config
-lib/systemd/system/*
+usr/lib/systemd/user/*
 usr/share/ddupdate
 usr/share/man/man8/ddupdate*
 usr/share/man/man5/ddupdate*

--- a/debian/rules
+++ b/debian/rules
@@ -8,9 +8,5 @@ override_dh_auto_install:
 	    install --root=debian/tmp --install-layout=deb
 	py3clean debian/tmp
 
-override_dh_installsystemd:
-	dh_installsystemd --no-enable ddupdate.timer
-	dh_installsystemd --no-enable ddupdate.service
-
 override_dh_missing:
 	dh_missing --fail-missing


### PR DESCRIPTION
As of b49006e, systemd units are not in `/lib/systemd/system`, instead they are in `/usr/lib/systemd/user`.  This MR anticipates the merge of that commit into the debian branch. Moreover, with this change, debian builds after merging master into it.