### PR TITLE
Replace "is not" used with literal string.

### DIFF
--- a/lib/ddupdate/ddplugin.py
+++ b/lib/ddupdate/ddplugin.py
@@ -175,7 +175,7 @@ class IpAddr(object):
 
         """
         for line in text.split('\n'):
-            words = [ word for word in line.split(' ') if word is not '' ]
+            words = [ word for word in line.split(' ') if word != '' ]
             if words[0] == 'inet':
                 # use existing logic
                 self.v4 = words[1].split('/')[0]


### PR DESCRIPTION
This trivial patch silences a warning:

    SyntaxWarning: "is not" with a literal. Did you mean "!="?

Otherwise, this shows up every time ddupdate is called.