### PR TITLE
Fix a syntax typo

### DIFF
--- a/plugins/changeip.py
+++ b/plugins/changeip.py
@@ -38,5 +38,5 @@ class ChangeAddressPlugin(ServicePlugin):
             url += "&ip=" + ip.v4
         http_basic_auth_setup(url)
         html = get_response(log, url)
-        if not'uccessful' in html:
+        if not 'uccessful' in html:
             raise ServiceError("Bad update reply: " + html)


### PR DESCRIPTION
This worked for now, but is SyntaxError in Python 3.9.0a6:

```
***   File "/usr/share/ddupdate/plugins/changeip.py", line 41
    if not'uccessful' in html:
         ^
SyntaxError: invalid string prefix
```

(The Python change might actually be [reverted](https://github.com/python/cpython/pull/19888) before 3.9 final, but this can be fixed anyway.)