### PR TITLE
nsupdate plugin: properly capture stderr

### DIFF
--- a/plugins/nsupdate.py
+++ b/plugins/nsupdate.py
@@ -33,7 +33,7 @@ class nsupdatePlugin(ServicePlugin):
         args = ('nsupdate',)
         if 'key' in opts:
             args += ('-k',opts['key'].encode('ascii'))
-        p = Popen(args,stdout=PIPE,stdin=PIPE)
+        p = Popen(args,stdout=PIPE,stdin=PIPE,stderr=PIPE)
         p.stdin.write(b'server '+opts['server'].encode('ascii')+b'\n')
         try:
             p.stdin.write(b'zone '+opts['zone'].encode('ascii')+b'\n')
@@ -51,5 +51,5 @@ class nsupdatePlugin(ServicePlugin):
                 p.stdin.write(b'update add '+hostname+b' 60 AAAA '+addr+b'\n')
         p.stdin.write(b'send\n')
         stdout,err = p.communicate()
-        if not(err is None):
-            raise ServiceError("Bad update reply: " + stdout.decode('ascii'))
+        if len(err) > 0:
+            raise ServiceError("Bad update reply: " + err.decode('ascii'))


### PR DESCRIPTION
I'm embarrassed to say that, while I have made heavy use of this plugin that I submitted last year, I only now have gotten around to fixing this silly mistake of mine.  The plugin does not recognize errors returned by `nsupdate`, because it isn't properly capturing stderr.  This patch fixes it.

The nsupdate plugin calls the same-named binary using the subprocess.Popen class, which by default, does NOT capture stderr output.  Because of this, errors occurring during calls to nsupdate are not properly reflected by ddupdate.

Set `stderr=PIPE`, and then check for any stderr output.  In the event of any such output, print the error output, and return failure.