### PR TITLE
Feature Add dnshome.de DynDNS-Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 fedora
 testing.txt
 install
+/.idea/

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -41,6 +41,7 @@ service by listing all available services (your list might differ)::
     cloudflare.com       Updates on https://cloudflare.com
     dnsdynamic.org       Updates on http://dnsdynamic.org/
     dnsexit.com          Updates on https://www.dnsexit.com
+    dnshome.de           Updates on https://www.dnshome.de
     dnspark.com          Updates on https://dnspark.com/
     dry-run              Debug dummy update plugin
     dtdns.com            Updates on https://www.dtdns.com

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+x.x.x
+* New `ip-version` is configurable using `ddupdate-config` command.
+* Update `update-config` does probe IPs from the selected service.
+* Update `update-config` is more robust to handle invalid selections.
+
 0.6.5
 * Fix ip route parsing (#35)
 * Fix python 3.9 syntax warnings (#38, #37)

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ x.x.x
 * New `ip-version` is configurable using `ddupdate-config` command.
 * Update `update-config` does probe IPs from the selected service.
 * Update `update-config` is more robust to handle invalid selections.
+* New service plugin dnshome.de
+* New address plugin ip.dnshome.de
 
 0.6.5
 * Fix ip route parsing (#35)

--- a/lib/ddupdate/config.py
+++ b/lib/ddupdate/config.py
@@ -1,4 +1,3 @@
-
 """Simple, CLI configuration script for ddupdate."""
 
 import configparser
@@ -7,6 +6,8 @@ import os
 import os.path
 import re
 import shutil
+from typing import Dict
+
 import stat
 import subprocess
 import sys
@@ -15,8 +16,7 @@ import time
 
 from ddupdate.main import \
     setup, build_load_path, envvar_default, load_plugin_dir
-from ddupdate.ddplugin import ServicePlugin, AddressPlugin
-
+from ddupdate.ddplugin import ServicePlugin, AddressPlugin, AddressError, IpVersion
 
 _CONFIG_TRAILER = """
 #
@@ -115,51 +115,144 @@ def get_service_plugin(service_plugins):
     """
     ix = 1
     services_by_ix = {}
+    use_service = False
+
     for id_ in sorted(service_plugins):
         print("%2d     %-18s     %s" %
               (ix, id_, service_plugins[id_].oneliner()))
         services_by_ix[ix] = service_plugins[id_]
         ix += 1
-    text = input("Select service to use: ")
-    try:
-        ix = int(text)
-    except ValueError:
-        raise _GoodbyeError("Illegal number format", 1)
-    if ix not in range(1, len(services_by_ix) + 1):
-        raise _GoodbyeError("Illegal selection\n", 2)
+
+    while not use_service:
+        reply = input("Select service to use: ")
+
+        try:
+            ix = int(reply)
+        except ValueError:
+            ix = 0
+
+        if ix not in range(1, len(services_by_ix) + 1):
+            reply = input("Invalid option selected, try again? (Yes/No) [Yes]: ")
+            if reply and reply.lower().startswith('n'):
+                raise _GoodbyeError("Configuration aborted by user", 1)
+        else:
+            use_service = True
+
     return services_by_ix[ix]
 
 
-def get_address_plugin(log, paths):
+def get_address_plugin(
+        log: logging.Logger,
+        address_plugins: Dict[str, AddressPlugin],
+        address_options: [str],
+        default_plugin_id: str = 'default-web-ip') -> AddressPlugin:
     """
     Let user select address plugin.
 
     Parameters:
       - log: Standard python log instance.
-      - paths: List of strings, directory paths to load plugins from.
+      - address_plugins: Dict of loaded plugins keyed by plugin.name()
+      - address_options: Options from --address-options
+      - default_plugin_id: ID of the plugin to use by default if nothing is selected
 
     Return:
-      Name of selected address plugin.
+      A loaded plugin as selected by user.
 
     """
-    plugins = _load_addressers(log, paths)
-    web_default_ip = plugins['default-web-ip']
-    default_if = plugins['default-if']
-    print("Probing for addresses, can take some time...")
-    if_addr = default_if.get_ip(log, [])
-    web_addr = web_default_ip.get_ip(log, [])
-    print("1  Use address as seen from Internet [%s]" % web_addr.v4)
-    print("2  Use address as seen on local network [%s]" % if_addr.v4)
-    print("3  Use address as decided by service")
-    ix = input("Select address to register (1, 2, 3) [1]: ").strip()
-    ix = ix if ix else '1'
-    plugin_by_ix = {
-        '1': 'default-web-ip', '2': 'default-if', '3': 'ip-disabled'
-    }
-    if ix in plugin_by_ix:
-        return plugin_by_ix[ix]
-    else:
-        raise _GoodbyeError("Illegal value", 1)
+
+    ix = 1
+    plugins_by_ix = {}
+    default_plugin_ix = 1
+    use_plugin = False
+
+    for id_ in sorted(address_plugins):
+        print("%2d     %-18s     %s" % (ix, id_, address_plugins[id_].oneliner()))
+
+        plugins_by_ix[ix] = address_plugins[id_]
+
+        if default_plugin_id == id_:
+            default_plugin_ix = ix  # Update default index based on the actual position of the default_plugin_id
+
+        ix += 1
+
+    # Let the user continuously select until satisfied.
+    while not use_plugin:
+        reply = input("Select address-plugin to resolve ip-addresses [%d]: " % default_plugin_ix).strip()
+
+        try:
+            ix = int(reply.strip() if reply else default_plugin_ix)
+        except ValueError:
+            ix = 0
+
+        if ix in plugins_by_ix:
+            print("Probing for addresses, can take some time...")
+            try:
+                # Probe IPs from selected service
+                ip = plugins_by_ix[ix].get_ip(log, address_options)
+                if not ip or ip.empty():
+                    print("Service did not respond with a ip-address.")
+                    reply = input("Use this service anyway? (Yes/No) [No]: ")
+                    use_plugin = reply and reply.lower().startswith('y')
+                else:
+                    print("Received IPv4-address: %s" % ip.v4)
+                    print("Received IPv6-address: %s" % ip.v6)
+                    reply = input("Use this service? (Yes/No) [Yes]: ")
+                    use_plugin = not reply or reply.lower().startswith('y')
+            except AddressError as err:
+                print("Error obtaining ip-addresses: %s" % err)
+                reply = input("Try another service? (Yes/No) [Yes]: ")
+                if reply and not reply.lower().startswith('n'):
+                    use_plugin = True
+        else:
+            reply = input("Invalid option selected, try again? (Yes/No) [Yes]: ")
+            if reply and reply.lower().startswith('n'):
+                raise _GoodbyeError("Configuration aborted by user", 1)
+
+    return plugins_by_ix[ix]
+
+
+def get_ip_version(default_version: IpVersion = IpVersion.V4) -> str:
+    """Let user select the ip-version.
+
+    Parameters:
+      - default_version: ip-version enum value to be used if none is selected.
+
+    Return:
+      The ip-version string as selected by the user.
+
+    """
+    versions_by_ix = {}
+    default_version_ix = 1
+    use_version = False
+
+    for ix, version in enumerate(IpVersion, 1):
+        print("%2d     %s" % (ix, version.value))
+
+        versions_by_ix[ix] = version
+
+        if default_version is version:
+            default_version_ix = ix  # Update default index based on the actual position of the default_version
+
+        ix += 1
+
+    # Let the user continuously select until satisfied.
+    ix = default_version_ix
+    while not use_version:
+        reply = input("Select ip-version to update [%d]: " % default_version_ix).strip()
+
+        try:
+            ix = int(reply.strip() if reply else default_version_ix)
+        except ValueError:
+            ix = 0
+
+        if ix in versions_by_ix:
+            use_version = True
+        else:
+            reply = input("Invalid option selected, try again? (Yes/No) [Yes]: ")
+            if reply and reply.lower().startswith('n'):
+                raise _GoodbyeError("Configuration aborted by user", 1)
+
+    return versions_by_ix[ix].name.lower()
 
 
 def copy_systemd_units():
@@ -355,11 +448,14 @@ def main():
         service = get_service_plugin(service_plugins)
         netrc = get_netrc(service)
         hostname = input("[%s] hostname: " % service.name())
-        address_plugin = get_address_plugin(log, load_paths)
+        address_plugins = _load_addressers(log, load_paths)
+        address_plugin = get_address_plugin(log, address_plugins, [])
+        ip_version = get_ip_version()
         conf = {
-            'address-plugin': address_plugin,
+            'address-plugin': address_plugin.name(),
             'service-plugin': service.name(),
-            'hostname': hostname
+            'hostname': hostname,
+            'ip-version': ip_version,
         }
         write_config_files(conf, netrc)
         try_start_service()
@@ -372,6 +468,5 @@ def main():
 
 if __name__ == '__main__':
     main()
-
 
 # vim: set expandtab ts=4 sw=4:

--- a/lib/ddupdate/config.py
+++ b/lib/ddupdate/config.py
@@ -16,7 +16,8 @@ import time
 
 from ddupdate.main import \
     setup, build_load_path, envvar_default, load_plugin_dir
-from ddupdate.ddplugin import ServicePlugin, AddressPlugin, AddressError, IpVersion
+from ddupdate.ddplugin import \
+    ServicePlugin, AddressPlugin, AddressError, IpVersion
 
 _CONFIG_TRAILER = """
 #
@@ -166,18 +167,21 @@ def get_address_plugin(
     use_plugin = False
 
     for id_ in sorted(address_plugins):
-        print("%2d     %-18s     %s" % (ix, id_, address_plugins[id_].oneliner()))
+        print("%2d     %-18s     %s"
+              % (ix, id_, address_plugins[id_].oneliner()))
 
         plugins_by_ix[ix] = address_plugins[id_]
 
+        # Update default index based on the actual position of the default_plugin_id
         if default_plugin_id == id_:
-            default_plugin_ix = ix  # Update default index based on the actual position of the default_plugin_id
+            default_plugin_ix = ix
 
         ix += 1
 
     # Let the user continuously select until satisfied.
     while not use_plugin:
-        reply = input("Select address-plugin to resolve ip-addresses [%d]: " % default_plugin_ix).strip()
+        reply = input("Select address-plugin to resolve ip-addresses [%d]: "
+                      % default_plugin_ix).strip()
 
         try:
             ix = int(reply.strip() if reply else default_plugin_ix)
@@ -230,15 +234,17 @@ def get_ip_version(default_version: IpVersion = IpVersion.V4) -> str:
 
         versions_by_ix[ix] = version
 
+        # Update default index based on the actual position of the default_version
         if default_version is version:
-            default_version_ix = ix  # Update default index based on the actual position of the default_version
+            default_version_ix = ix
 
         ix += 1
 
     # Let the user continuously select until satisfied.
     ix = default_version_ix
     while not use_version:
-        reply = input("Select ip-version to update [%d]: " % default_version_ix).strip()
+        reply = input("Select ip-version to update [%d]: "
+                      % default_version_ix).strip()
 
         try:
             ix = int(reply.strip() if reply else default_version_ix)

--- a/lib/ddupdate/ddplugin.py
+++ b/lib/ddupdate/ddplugin.py
@@ -27,6 +27,8 @@ from urllib.parse import urlencode, urlparse
 from socket import timeout as timeoutError
 from netrc import netrc
 
+from enum import Enum
+
 URL_TIMEOUT = 120  # Default timeout in get_response()
 
 
@@ -194,6 +196,16 @@ class IpAddr(object):
                 self.v6 = addr
         if self.empty():
             raise AddressError("Cannot find address for %s, giving up" % text)
+
+
+class IpVersion(Enum):
+    """Enum holding valid values for the ip-version option.
+    The actual values are the enum-value names to lower-case
+    while their value represent human readable format.
+    """
+    ALL = 'All (IPv4 and IPv6)'
+    V4 = 'Pv4 only'
+    V6 = 'IPv6 only'
 
 
 class AddressError(Exception):

--- a/plugins/dnshome_de.py
+++ b/plugins/dnshome_de.py
@@ -1,0 +1,175 @@
+"""
+ddupdate plugin updating data on dnshome.de.
+
+See: ddupdate(8)
+See: https://www.dnshome.de/
+"""
+
+import urllib.request
+import urllib.error
+import ipaddress
+from typing import AnyStr, Optional
+from enum import Enum
+from logging import Logger
+
+from ddupdate.ddplugin import ServicePlugin, ServiceError
+from ddupdate.ddplugin import http_basic_auth_setup, get_response
+from ddupdate.ddplugin import AddressPlugin, IpAddr
+
+TIMEOUT = 20
+
+
+class DeDnsHomeAddressPlugin(ServicePlugin):
+    """Update a dns entry on dnshome.de.
+
+    Supports using most address plugins including default-web-ip, default-if and ip-disabled.
+
+    You cannot set the host explicitly using a parameter like `hostname`.
+    Even though the hostname is included in the query, it simply gets ignored.
+    Set the host you want to update as username (like: subdomain.dnshome.de).
+
+    Respects _global_ global `--ip-version` option.
+    Be sure to configure ddupdate according to your connection type.
+
+    netrc: Use a line like
+        machine www.dnshome.de login <username>  password <password>
+
+    Options:
+        none
+    """
+
+    _name = 'dnshome.de'
+    _oneliner = 'Updates on https://www.dnshome.de/'
+    _url = "https://www.dnshome.de/dyndns.php?&hostname={0}"
+
+    @staticmethod
+    def is_success(response: AnyStr) -> bool:
+        """Checks if the action was successful using the response
+
+        Args:
+            response: The response-body to analyze.
+
+        Returns:
+            true, if the response-body starts with
+                'good' - Update was successful
+                'nochg' - No change was performed, since records were already up to date.
+        """
+
+        return response.startswith('good') or response.startswith('nochg')
+
+    def register(self, log: Logger, hostname: str, ip: IpAddr, options):
+        """Implement ServicePlugin.register.
+        Expects the `ip` to be filtered already according to the _global_ `--ip-version` option.
+        """
+        url = self._url.format(hostname)
+
+        if ip:
+            if ip.v4:
+                url += '&ip=' + ip.v4
+            if ip.v6:
+                url += '&ip6=' + ip.v6
+
+        http_basic_auth_setup(url)
+
+        body = get_response(log, url)  # Get ASCII encoded body-content
+        if not DeDnsHomeAddressPlugin.is_success(body):
+            raise ServiceError("Bad update reply.\n"
+                               "This may be caused due to unauthorized or to frequent requests.\n"
+                               "Message: " + body)
+
+
+class DeDnshomeAddressURL(Enum):
+    """Enumeration of the available *.dnshome.de ip-resolver urls."""
+    IP4 = 'https://ip4.dnshome.de'
+    IP6 = 'https://ip6.dnshome.de'
+
+
+class DeDnshomeWebPlugin(AddressPlugin):
+    """Get the external IPv4 and/or IPv6 address as seen from ip.dnshome.de.
+    Depending on the type of your connection one or the other address may be `None`.
+    Also the presence of an IPv4 address does not guarantee that inbound connections
+    can be instantiated from external endpoints (see: DS-Lite and IPv6 tunneling).
+
+    Relies on [ip4|ip6].dnshome.de
+
+    Options used:
+        none
+    """
+
+    _name = 'ip.dnshome.de'
+    _oneliner = 'Obtain external IPv4 and/or IPv6 address as seen by dnshome.de'
+
+    @staticmethod
+    def extract_ip(data: AnyStr) -> IpAddr:
+        """Extracts the IPs from data
+        Expects `data` to be an UTF-8 string holding either an single IPv4 or an IPv6 address.
+
+        Args:
+            data: Data to extract the IP from
+
+        Returns:
+            An `IpAddr` which may hold the IPv4 or IPv6 Address found.
+        """
+
+        try:
+            ip = ipaddress.ip_address(data.strip())
+
+            if isinstance(ip, ipaddress.IPv4Address):
+                return IpAddr(ip.exploded, None)
+            if isinstance(ip, ipaddress.IPv6Address):
+                return IpAddr(None, ip.exploded)
+
+        except ValueError:
+            return IpAddr(None, None)
+
+    @staticmethod
+    def load_ip(log: Logger, url: str) -> Optional[IpAddr]:
+        """Loads the external IP from an remote Endpoint (url)
+        Expects the Endpoint to respond with an UTF-8-String containing the IP.
+
+        Args:
+            log: Logger
+            url: URL to Load the IP from
+
+        Returns:
+            An `IPAddr` holding the IPv4 and/or IPv6 Address found or `None`.
+        """
+
+        log.debug('loading ip from %s' % url)
+
+        try:
+            with urllib.request.urlopen(url, None, TIMEOUT) as response:
+                if response.getcode() != 200:
+                    log.debug("Bad response at %s (ignored)" % url)
+                    return None
+                body = response.read().decode()
+        except urllib.error.URLError as err:
+            log.debug("Got URLError: %s", err)
+            return None
+
+        log.debug("Got response: %s", body)
+
+        result = DeDnshomeWebPlugin.extract_ip(body)
+
+        if result.empty():
+            log.debug("Cannot parse IPv4/IPv6 address from response")
+            return None
+
+        return result
+
+    def get_ip(self, log: Logger, options: [str]) -> Optional[IpAddr]:
+        """Implements AddressPlugin.get_ip()"""
+
+        urls = [DeDnshomeAddressURL.IP4, DeDnshomeAddressURL.IP6]
+        ip = IpAddr(None, None)
+
+        for url in urls:
+            result = DeDnshomeWebPlugin.load_ip(log, url.value)
+
+            if result:
+                if not ip.v4 and result.v4:
+                    ip.v4 = result.v4
+                if not ip.v6 and result.v6:
+                    ip.v6 = result.v6
+
+        return ip if not ip.empty() else None

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class _ProjectInstall(install):
                 continue
             if option == "install_lib":
                 install_lib = value
-            s += option + " = " + (value if value else "") + "\n"
+            s += option + " = " + (str(value) if value else "") + "\n"
         if not install_lib:
             print("Warning: cannot create platform install paths file")
             return


### PR DESCRIPTION
I've added a service- and address- plugin for the, lesser known, dnshome.de DynDNS-Service.
Also i changed the `ddupdate-config` a little, so that the user can now choose the address-plugin to resolve the IP addresses and check the result immediatly. After that he/she can configure if IPv4, IPv6 or both shall be updated too.

I have tested the plugin against their Web-APIs manually as well as live in action.
For the test (and my own purpose) i've merged the changes into _/debian_ and ran `ddupdate-config` successfully on my Raspberry Pi 4b.

Environment Details:
Operating System: Raspbian GNU/Linux 10 (buster)
Kernel: Linux 5.4.79-v7l+
Architecture: arm

If you feel anything is wrong, do not hasitate to give me feedback and/or take changes as you like.