### PR TITLE
Add `requests` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Dependencies
 
   - python3 (tested on 3.6 and 3.4)
   - The /usr/sbin/ip command is used in some plugins.
+  - python3-requests  (runtime, for Cloudflare plugin)
   - python3-setuptools  (build)
   - pkg-config  (build)
   - The systemd package i. e., the systemd.pc file (build).

--- a/setup.py
+++ b/setup.py
@@ -96,5 +96,6 @@ setup(
     packages=['ddupdate'],
     scripts=['ddupdate', 'ddupdate-config'],
     data_files=DATA,
-    cmdclass={'clean': _ProjectClean, 'install': _ProjectInstall}
+    cmdclass={'clean': _ProjectClean, 'install': _ProjectInstall},
+    install_requires=['requests']
 )


### PR DESCRIPTION
`requests` is required for Cloudflare plugin.