### PR TITLE
Exit with code 4 on ServiceError

### DIFF
--- a/lib/ddupdate/main.py
+++ b/lib/ddupdate/main.py
@@ -458,6 +458,7 @@ def main():
         service_plugin.register(log, opts.hostname, ip, opts.service_options)
     except ServiceError as err:
         log.error("Cannot update DNS data: %s", err)
+        sys.exit(4)
     else:
         ip_cache_set(opts, ip)
         log.info("Update OK")


### PR DESCRIPTION
If update fails with ServiceError, ddupdate currently exits with code 0, which makes e.g. systemd units succeed.

Change ServiceError handling so that ddupdate exits with code 4.