### PR TITLE
Support multiple credentials with the same provider

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 0.7.0 TBD
 * Support multiple configuration sections in config file (#25)
 * Add FINAL_PREFIX environment variable support to ease packaging
+* Support multiple credentials for Google domains (#52)
 
 0.6.6
 * Fix wrong path in systemd service file (#54).

--- a/plugins/googledomains.py
+++ b/plugins/googledomains.py
@@ -5,10 +5,80 @@ See: ddupdate(8)
 See: https://support.google.com/domains/answer/6147083?hl=en
 
 """
+import netrc
+import os.path
 import urllib.parse
 import urllib.request
 from ddupdate.ddplugin import ServiceError, ServicePlugin, \
-    get_response, http_basic_auth_setup
+    get_response
+
+
+# See https://github.com/leamas/ddupdate/pull/56
+# and https://github.com/leamas/ddupdate/issues/52
+# for why these functions are specialized here.
+def http_basic_auth_setup(url, *, providerhost=None, targethost=None):
+    """
+    Configure urllib to provide basic authentication.
+
+    See get_netrc_auth for how providerhost and targethost
+    are resolved to credentials stored in netrc.
+
+    Parameters:
+        - url: string, the url to connect to.
+        - providerhost: string, a hostname representing the provider.
+          Defaults to the hostname part of url.
+        - targethost: string, the host being updated.  Optional, used
+          to discriminate hosts registered with different
+          credentials at the same provider.
+    """
+    if not providerhost:
+        providerhost = urllib.parse.urlparse(url).hostname
+    user, password = get_netrc_auth(providerhost, targethost)
+    pwmgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    pwmgr.add_password(None, url, user, password)
+    auth_handler = urllib.request.HTTPBasicAuthHandler(pwmgr)
+    opener = urllib.request.build_opener(auth_handler)
+    urllib.request.install_opener(opener)
+
+def get_netrc_auth(providerhost, targethost=None):
+    """
+    Retrieve data from  ~/-netrc or /etc/netrc.
+
+    Will look for matching identifiers in the netrc file.
+
+    If a targethost is passed, the first machine name we look for
+    is targethost.providerhost.ddupdate, falling back to providerhost.
+    If no targethost is passed, we only look for providerhost.
+
+    Parameters:
+      - providerhost: identifies the dns provider
+      - targethost: optional.  Allows selecting credentials for multiple
+        host names registered at the same provider.
+    Returns:
+      - A (user, password) tuple. User might be None.
+    Raises:
+      - ServiceError if .netrc or password is not found.
+    See:
+      - netrc(5)
+
+    """
+    if os.path.exists(os.path.expanduser('~/.netrc')):
+        path = os.path.expanduser('~/.netrc')
+    elif os.path.exists('/etc/netrc'):
+        path = '/etc/netrc'
+    else:
+        raise ServiceError("Cannot locate the netrc file (see manpage).")
+    netrcdata = netrc.netrc(path)
+    if targethost is not None:
+        machine1 = "%s.%s.ddupdate" % (targethost, providerhost)
+        auth = netrcdata.authenticators(machine1) or netrcdata.authenticators(providerhost)
+    else:
+        auth = netrcdata.authenticators(providerhost)
+    if not auth:
+        raise ServiceError("No .netrc data found for " + providerhost)
+    if not auth[2]:
+        raise ServiceError("No password found for " + providerhost)
+    return auth[0], auth[2]
 
 
 class GoogleDomainsPlugin(ServicePlugin):
@@ -37,7 +107,7 @@ class GoogleDomainsPlugin(ServicePlugin):
             query['myip'] = ip.v6 or ip.v4
 
         url="{}?{}".format(self._url, urllib.parse.urlencode(query))
-        http_basic_auth_setup(url)
+        http_basic_auth_setup(url, targethost=hostname)
         request = urllib.request.Request(url=url, method='POST')
         html = get_response(log, request)
 


### PR DESCRIPTION
Some dynamic dns providers (like Google domains) support updating
multiple hosts, each with their own API credentials.

To specify credentials that are specific to a target domain
at a provider, put the following in ~/.netrc:

    machine mydomain.tld.domains.google.com.ddupdate login AAA password BBB
    machine mydomain2.tld.domains.google.com.ddupdate login CCC password DDD

With machine of the form:

    targetdomain.providerdomain.ddupdate

Closes #52.