### PR TITLE
New address plugin for OnHub / Google WiFi / Nest WiFi

### DIFF
--- a/plugins/onhub.py
+++ b/plugins/onhub.py
@@ -1,0 +1,47 @@
+"""
+ddupdate plugin to retrieve address from an OnHub / Google / Nest router.
+
+See: ddupdate(8)
+"""
+
+import json
+import urllib.request
+
+from ddupdate.ddplugin import AddressPlugin, AddressError, IpAddr
+
+
+# onhub.here should resolve correctly if you have this type of router
+_URL = "http://onhub.here/api/v1/status"
+
+
+class OnHubPlugin(AddressPlugin):
+    """
+    Get the external address via the OnHub status API.
+
+    Options used: none
+    """
+
+    _name = "onhub"
+    _oneliner = "Obtain external address from OnHub / Google / Nest router"
+
+    def get_ip(self, log, options):
+        """Implement AddressPlugin.get_ip()."""
+        # Documentation refers to testing on 3.4
+        # f-strings are from 3.6 and exception chaining from 3.9
+        # pylint: disable=consider-using-f-string,raise-missing-from
+        log.debug("trying " + _URL)
+        try:
+            with urllib.request.urlopen(_URL) as response:
+                if response.getcode() != 200:
+                    raise AddressError(
+                        "Bad response %s from %s" % (response.getcode(), _URL)
+                    )
+                status = json.loads(response.read().decode("utf-8"))
+        except (urllib.error.HTTPError, urllib.error.URLError) as err:
+            raise AddressError("Error reading %s :%s" % (_URL, err))
+        log.debug("Got response: %s", json.dumps(status))
+
+        log.debug("WAN online: %s", status["wan"]["online"])
+
+        # TODO: Can we also get an external IPv6 address?
+        return IpAddr(status["wan"]["localIpAddress"])


### PR DESCRIPTION
This is a plugin to fetch the external IP address directly from an OnHub, Google WiFi, or Nest WiFi router via their v1 API.

I don't have an external IPv6 address, so I'm unsure what (if any) the API response looks like if IPv6 is enabled, but perhaps someone with an ISP that supports IPv6 can help there.

The complete response from mine is included in the DEBUG log below in case it's helpful in maintaining this plugin.

```log
$ ddupdate -a onhub -l debug
WARNING - Cannot open config file '/etc/ddupdate.conf' for read
DEBUG - Using config file: None
INFO - Loglevel: DEBUG
INFO - Using hostname: host.nowhere.net
INFO - Using ip address plugin: onhub
INFO - Using service plugin: dry-run
INFO - Service options: 
INFO - Address options: 
DEBUG - paths :/usr/lib/python3:/home/pi/.local/share/ddupdate:/usr/local/share/ddupdate:/usr/share/ddupdate
DEBUG - Loaded 0 address and 0 service plugins from /usr/lib/python3
DEBUG - Loaded 0 address and 0 service plugins from /home/pi/.local/share/ddupdate
DEBUG - Loaded 0 address and 0 service plugins from /usr/local/share/ddupdate
DEBUG - Loaded 8 address and 21 service plugins from /usr/share/ddupdate
DEBUG - trying http://onhub.here/api/v1/status
DEBUG - Got response: {"setupState": "GWIFI_OOBE_COMPLETE", "software": {"blockingUpdate": 1, "softwareVersion": "13729.57.27", "updateChannel": "stable-channel", "updateNewVersion": "0.0.0.0", "updateProgress": 0.0, "updateRequired": false, "updateStatus": "idle"}, "system": {"countryCode": "us", "groupRole": "root", "hardwareId": "GALE C2E-A2A-A3A-A5A-A46", "lan0Link": true, "modelId": "ACjYe", "uptime": 3072876}, "vorlonInfo": {"migrationMode": "voobed"}, "wan": {"captivePortal": false, "ethernetLink": true, "gatewayIpAddress": "50.47.96.1", "invalidCredentials": false, "ipAddress": true, "ipMethod": "dhcp", "ipPrefixLength": 21, "leaseDurationSeconds": 14400, "localIpAddress": "50.47.102.160", "nameServers": ["8.8.8.8", "8.8.4.4", "74.40.74.40", "192.152.0.1", "192.152.0.2"], "online": true, "pppoeDetected": false, "vlanScanAttemptCount": 0, "vlanScanComplete": true}}
DEBUG - WAN online: True
INFO - Using ip address: ['50.47.102.160', None]
INFO - Update inhibited, cache is fresh (0/1 min)
```