### PR TITLE
Include hostnames into cache filenames

### DIFF
--- a/lib/ddupdate/main.py
+++ b/lib/ddupdate/main.py
@@ -63,7 +63,8 @@ def ip_cache_setup(opts):
     """Ensure that our cache directory exists, return cache file path."""
     if not os.path.exists(opts.ip_cache):
         os.makedirs(opts.ip_cache)
-    return os.path.join(opts.ip_cache, opts.service_plugin + '.ip')
+    return os.path.join(opts.ip_cache, opts.service_plugin + '_' +
+                                       opts.hostname + '.ip')
 
 
 def ip_cache_clear(opts, log):

--- a/plugins/auth_netrc.py
+++ b/plugins/auth_netrc.py
@@ -23,7 +23,10 @@ class AuthNetrc(AuthPlugin):
 
     def get_auth(self, machine):
         """Implement AuthPlugin::get_auth()."""
-        if os.path.exists(os.path.expanduser('~/.netrc')):
+        path = os.environ.get('NETRC', '')
+        if path:
+            pass
+        elif os.path.exists(os.path.expanduser('~/.netrc')):
             path = os.path.expanduser('~/.netrc')
         elif os.path.exists('/etc/netrc'):
             path = '/etc/netrc'


### PR DESCRIPTION
If a single host registered with two distinct names at the same service,
the cache prevented the second one from being updated.