### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,11 @@
 import shutil
 import os
 import subprocess
+from glob import glob
 
+from setuptools import setup
 from distutils.command.clean import clean
 from distutils.command.install import install
-
-from glob import glob
-from setuptools import setup
 
 ROOT = os.path.dirname(__file__)
 ROOT = ROOT if ROOT else '.'


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022527