### PR TITLE
Also ignore temporary ipv6 addresses

### DIFF
--- a/lib/ddupdate/ddplugin.py
+++ b/lib/ddupdate/ddplugin.py
@@ -198,6 +198,9 @@ class IpAddr:
                 if 'deprecated' in words:
                     # don't use a "deprecated" address
                     continue
+                if 'temporary' in words:
+                    # don't use a "temporary" address
+                    continue
                 self.v6 = addr
         if self.empty():
             raise AddressError("Cannot find address for %s, giving up" % text)


### PR DESCRIPTION
When privacy extensions are enabled the preferred _outgoing_ address is a temporary one with a short lifetime. Using these for DNS (and thus incoming connections) doesn't seem to make much sense, so ignore them here.