### PR TITLE
add_default_ip extras

### DIFF
--- a/lib/ddupdate/ddplugin.py
+++ b/lib/ddupdate/ddplugin.py
@@ -171,7 +171,7 @@ class IpAddr:
         """Check if any address is set."""
         return self.v4 is None and self.v6 is None
 
-    def parse_ifconfig_output(self, text):
+    def parse_ifconfig_output(self, text, link='false'):
         """
         Update v4 and v6 attributes by parsing ifconfig(8) or ip(8) output.
 
@@ -192,11 +192,15 @@ class IpAddr:
                     continue
                 addr = words[1].split('/')[0]
                 words = set(words[2:])
-                if ('link' in words) or ('0x20<link>' in words):
-                    # don't use a link-local address
-                    continue
                 if 'deprecated' in words:
                     # don't use a "deprecated" address
+                    continue
+                if ('link' in words) or ('0x20<link>' in words):
+                    if link.lower() == 'false':
+                        # don't use a link-local address
+                        continue
+                elif link.lower() == 'force':
+                    # force use of a link-local address
                     continue
                 self.v6 = addr
         if self.empty():

--- a/plugins/addr_default_ip.py
+++ b/plugins/addr_default_ip.py
@@ -6,7 +6,7 @@ See: ddupdate(8)
 
 import subprocess
 
-from ddupdate.ddplugin import AddressPlugin, AddressError, IpAddr
+from ddupdate.ddplugin import AddressPlugin, AddressError, IpAddr, dict_of_opts
 
 
 def find_device(words):
@@ -27,7 +27,8 @@ class DefaultIfPLugin(AddressPlugin):
     Digs in the routing tables and returns it's address using linux-specific
     code based on the ip utility which must be in $PATH
 
-    Options used: none
+    Options used:
+       link
     """
 
     _name = 'default-if'
@@ -37,6 +38,7 @@ class DefaultIfPLugin(AddressPlugin):
         """
         Get default interface using ip route and address using ifconfig.
         """
+        opts = dict_of_opts(options)
         if_ = None
         for line in subprocess.getoutput('ip route').split('\n'):
             words = line.split()
@@ -47,5 +49,5 @@ class DefaultIfPLugin(AddressPlugin):
             raise AddressError("Cannot find default interface, giving up")
         address = IpAddr()
         output = subprocess.getoutput('ip address show dev ' + if_)
-        address.parse_ifconfig_output(output)
+        address.parse_ifconfig_output(output, opts.get('link', 'false'))
         return address

--- a/plugins/addr_default_ip.py
+++ b/plugins/addr_default_ip.py
@@ -40,7 +40,16 @@ class DefaultIfPLugin(AddressPlugin):
         """
         opts = dict_of_opts(options)
         if_ = None
-        for line in subprocess.getoutput('ip route').split('\n'):
+        remote = opts.get('remote', None)
+        if remote:
+            key = opts.get('key', None)
+            if key:
+                prefix = f"ssh -i {key} {remote} "
+            else:
+                prefix = f"ssh {remote} "
+        else:
+            prefix = ""
+        for line in subprocess.getoutput(''.join((prefix, 'ip route'))).split('\n'):
             words = line.split()
             if words[0] == 'default':
                 if_ = find_device(words)
@@ -48,6 +57,6 @@ class DefaultIfPLugin(AddressPlugin):
         if if_ is None:
             raise AddressError("Cannot find default interface, giving up")
         address = IpAddr()
-        output = subprocess.getoutput('ip address show dev ' + if_)
+        output = subprocess.getoutput(''.join((prefix, 'ip address show dev ', if_)))
         address.parse_ifconfig_output(output, opts.get('link', 'false'))
         return address

--- a/plugins/addr_hardcoded_if.py
+++ b/plugins/addr_hardcoded_if.py
@@ -15,6 +15,7 @@ class HardcodedIfPlugin(AddressPlugin):
 
     Options:
         if=interface
+        link
     """
 
     _name = 'hardcoded-if'
@@ -28,5 +29,5 @@ class HardcodedIfPlugin(AddressPlugin):
         if_ = opts['if']
         address = IpAddr()
         output = subprocess.getoutput('ip address show dev ' + if_)
-        address.parse_ifconfig_output(output)
+        address.parse_ifconfig_output(output, opts.get('link', '0'))
         return address


### PR DESCRIPTION
Hello!  I've been using these two patches locally, and thought they might be useful for others.

The first adds the ability to force the use of a link-local address. This can be useful when publishing services that can only be used on a LAN, or alternatively for some "split-horizon" dns setups.

The second one provides a mechanism to prepend `ssh` and some key-file options before the calls made to `ip`.  This allows for several useful setups that can be otherwise challenging, such as using ddupdate to manage the dns entries for a system that cannot run ddupdate, centralizing all dns updates on a single machine, or using a router's `ip` command to infer a global ipv4 address instead of calling out to a remote server with `addr_default_web.py`.